### PR TITLE
temporarily disable iana-time-zone on macos/ios

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,8 @@ serde = { version = "1.0.99", default-features = false, optional = true }
 pure-rust-locales = { version = "0.5.2", optional = true }
 criterion = { version = "0.3", optional = true }
 rkyv = {version = "0.7", optional = true}
+
+[target.'cfg(not(any(target_os = "macos", target_os = "ios")))'.dependencies]
 iana-time-zone = { version = "0.1.41", optional = true, features = ["fallback"] }
 
 [target.'cfg(all(target_arch = "wasm32", not(any(target_os = "emscripten", target_os = "wasi"))))'.dependencies]

--- a/src/offset/local/unix.rs
+++ b/src/offset/local/unix.rs
@@ -103,6 +103,12 @@ const TZDB_LOCATION: &str = " /system/usr/share/zoneinfo";
 #[cfg(not(target_os = "android"))]
 const TZDB_LOCATION: &str = "/usr/share/zoneinfo";
 
+#[cfg(any(target_os = "macos", target_os = "ios"))]
+fn fallback_timezone() -> Option<TimeZone> {
+    Some(TimeZone::utc())
+}
+
+#[cfg(not(any(target_os = "macos", target_os = "ios")))]
 fn fallback_timezone() -> Option<TimeZone> {
     let tz_name = iana_time_zone::get_timezone().ok()?;
     let bytes = fs::read(format!("{}/{}", TZDB_LOCATION, tz_name)).ok()?;


### PR DESCRIPTION
This disables `iana-time-zone` on macos/ios to avoid cyclic dependency. 
