### PR TITLE
Update iana-time-zone to 0.1.44

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -173,6 +173,30 @@ jobs:
           RUST_VERSION: stable
           WASM: wasm_unknown
 
+  wasm_unknown_no_wasmbind:
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Install rust
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          target: wasm32-unknown-unknown
+          override: true
+          default: true
+
+      - name: Build and Test
+        run: bash ci/github.sh
+        env:
+          RUST_VERSION: stable
+          WASM: wasm_unknown_no_wasmbind
+
   wasm_wasi:
     strategy:
       matrix:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -86,6 +86,28 @@ jobs:
         run: cargo build --target thumbv6m-none-eabi --color=always
         working-directory: ./ci/core-test
 
+  intel_sgx:
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Install rust with fortanix sgx toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: nightly
+          target: x86_64-fortanix-unknown-sgx
+          override: true
+      - uses: Swatinem/rust-cache@v1
+
+      - name: Build sgx lib
+        run: cargo build --target x86_64-fortanix-unknown-sgx --color=always
+        working-directory: ./ci/core-test
+
   wasm:
     strategy:
       matrix:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ breakage if you use `no-default-features`.
 There were/are numerous minor versions before 1.0 due to the language changes.
 Versions with only mechanical changes will be omitted from the following list.
 
+## 0.4.22 (unreleased)
+
+* Fix circular dependency problems between iana-time-zone, core-foundation, and chrono
+
 ## 0.4.20 (unreleased)
 
 * Add more formatting documentation and examples.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,13 +20,13 @@ appveyor = { repository = "chronotope/chrono" }
 name = "chrono"
 
 [features]
-default = ["clock", "std", "oldtime"]
+default = ["clock", "std", "oldtime", "wasmbind"]
 alloc = []
 libc = []
 std = []
 clock = ["std", "winapi", "iana-time-zone"]
 oldtime = ["time"]
-wasmbind = [] # TODO: empty feature to avoid breaking change in 0.4.20, can be removed later
+wasmbind = ["wasm-bindgen", "js-sys"]
 unstable-locales = ["pure-rust-locales", "alloc"]
 __internal_bench = ["criterion"]
 __doctest = []
@@ -42,8 +42,8 @@ criterion = { version = "0.3", optional = true }
 rkyv = {version = "0.7", optional = true}
 
 [target.'cfg(all(target_arch = "wasm32", not(any(target_os = "emscripten", target_os = "wasi"))))'.dependencies]
-wasm-bindgen = { version = "0.2" }
-js-sys = { version = "0.3" } # contains FFI bindings for the JS Date API
+wasm-bindgen = { version = "0.2", optional = true }
+js-sys = { version = "0.3", optional = true } # contains FFI bindings for the JS Date API
 
 [target.'cfg(not(any(target_os = "emscripten", target_os = "wasi", target_os = "solaris")))'.dependencies]
 iana-time-zone = { version = "0.1.41", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,7 @@ serde = { version = "1.0.99", default-features = false, optional = true }
 pure-rust-locales = { version = "0.5.2", optional = true }
 criterion = { version = "0.3", optional = true }
 rkyv = {version = "0.7", optional = true}
-iana-time-zone = { version = "0.1.41", optional = true, features = ["fallback"] }
+iana-time-zone = { version = "0.1.44", optional = true, features = ["fallback"] }
 
 [target.'cfg(all(target_arch = "wasm32", not(any(target_os = "emscripten", target_os = "wasi"))))'.dependencies]
 wasm-bindgen = { version = "0.2", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,13 +40,12 @@ serde = { version = "1.0.99", default-features = false, optional = true }
 pure-rust-locales = { version = "0.5.2", optional = true }
 criterion = { version = "0.3", optional = true }
 rkyv = {version = "0.7", optional = true}
+iana-time-zone = { version = "0.1.41", optional = true, features = ["fallback"] }
 
 [target.'cfg(all(target_arch = "wasm32", not(any(target_os = "emscripten", target_os = "wasi"))))'.dependencies]
 wasm-bindgen = { version = "0.2", optional = true }
 js-sys = { version = "0.3", optional = true } # contains FFI bindings for the JS Date API
 
-[target.'cfg(not(any(target_os = "emscripten", target_os = "wasi", target_os = "solaris", target_env = "sgx")))'.dependencies]
-iana-time-zone = { version = "0.1.41", optional = true }
 
 [target.'cfg(windows)'.dependencies]
 winapi = { version = "0.3.0", features = ["std", "minwinbase", "minwindef", "timezoneapi"], optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,7 +45,7 @@ rkyv = {version = "0.7", optional = true}
 wasm-bindgen = { version = "0.2", optional = true }
 js-sys = { version = "0.3", optional = true } # contains FFI bindings for the JS Date API
 
-[target.'cfg(not(any(target_os = "emscripten", target_os = "wasi", target_os = "solaris")))'.dependencies]
+[target.'cfg(not(any(target_os = "emscripten", target_os = "wasi", target_os = "solaris", target_env = "sgx")))'.dependencies]
 iana-time-zone = { version = "0.1.41", optional = true }
 
 [target.'cfg(windows)'.dependencies]

--- a/ci/github.sh
+++ b/ci/github.sh
@@ -38,6 +38,8 @@ meaningful in the github actions feature matrix UI.
             test_wasm_emscripten
         elif [[ ${WASM:-} == wasm_unknown ]]; then
             test_wasm_unknown
+        elif [[ ${WASM:-} == wasm_unknown_no_wasmbind ]]; then
+            test_wasm_unknown_no_wasmbind
         elif [[ ${WASM:-} == wasm_wasi ]]; then
             test_wasm_wasi
         elif [[ ${CORE:-} == no_std ]]; then
@@ -124,6 +126,10 @@ test_wasm_emscripten() {
 
 test_wasm_unknown() {
     runt cargo build --target wasm32-unknown-unknown
+}
+
+test_wasm_unknown_no_wasmbind() {
+    runt cargo build --target wasm32-unknown-unknown --no-default-features --features clock,std
 }
 
 test_wasm_wasi() {

--- a/src/datetime/mod.rs
+++ b/src/datetime/mod.rs
@@ -994,21 +994,33 @@ impl<Tz: TimeZone> From<DateTime<Tz>> for SystemTime {
     }
 }
 
-#[cfg(all(target_arch = "wasm32", not(any(target_os = "emscripten", target_os = "wasi"))))]
+#[cfg(all(
+    target_arch = "wasm32",
+    feature = "wasmbind",
+    not(any(target_os = "emscripten", target_os = "wasi"))
+))]
 impl From<js_sys::Date> for DateTime<Utc> {
     fn from(date: js_sys::Date) -> DateTime<Utc> {
         DateTime::<Utc>::from(&date)
     }
 }
 
-#[cfg(all(target_arch = "wasm32", not(any(target_os = "emscripten", target_os = "wasi"))))]
+#[cfg(all(
+    target_arch = "wasm32",
+    feature = "wasmbind",
+    not(any(target_os = "emscripten", target_os = "wasi"))
+))]
 impl From<&js_sys::Date> for DateTime<Utc> {
     fn from(date: &js_sys::Date) -> DateTime<Utc> {
         Utc.timestamp_millis(date.get_time() as i64)
     }
 }
 
-#[cfg(all(target_arch = "wasm32", not(any(target_os = "emscripten", target_os = "wasi"))))]
+#[cfg(all(
+    target_arch = "wasm32",
+    feature = "wasmbind",
+    not(any(target_os = "emscripten", target_os = "wasi"))
+))]
 impl From<DateTime<Utc>> for js_sys::Date {
     /// Converts a `DateTime<Utc>` to a JS `Date`. The resulting value may be lossy,
     /// any values that have a millisecond timestamp value greater/less than ±8,640,000,000,000,000

--- a/src/offset/local/mod.rs
+++ b/src/offset/local/mod.rs
@@ -16,7 +16,11 @@ use crate::{Date, DateTime};
 #[cfg(all(
     not(unix),
     not(windows),
-    not(all(target_arch = "wasm32", not(any(target_os = "emscripten", target_os = "wasi"))))
+    not(all(
+        target_arch = "wasm32",
+        feature = "wasmbind",
+        not(any(target_os = "emscripten", target_os = "wasi"))
+    ))
 ))]
 #[path = "stub.rs"]
 mod inner;
@@ -59,6 +63,7 @@ impl Local {
     /// Returns a `DateTime` which corresponds to the current date and time.
     #[cfg(not(all(
         target_arch = "wasm32",
+        feature = "wasmbind",
         not(any(target_os = "emscripten", target_os = "wasi"))
     )))]
     pub fn now() -> DateTime<Local> {
@@ -66,7 +71,11 @@ impl Local {
     }
 
     /// Returns a `DateTime` which corresponds to the current date and time.
-    #[cfg(all(target_arch = "wasm32", not(any(target_os = "emscripten", target_os = "wasi"))))]
+    #[cfg(all(
+        target_arch = "wasm32",
+        feature = "wasmbind",
+        not(any(target_os = "emscripten", target_os = "wasi"))
+    ))]
     pub fn now() -> DateTime<Local> {
         use super::Utc;
         let now: DateTime<Utc> = super::Utc::now();
@@ -110,7 +119,11 @@ impl TimeZone for Local {
         midnight.map(|datetime| Date::from_utc(*local, *datetime.offset()))
     }
 
-    #[cfg(all(target_arch = "wasm32", not(any(target_os = "emscripten", target_os = "wasi"))))]
+    #[cfg(all(
+        target_arch = "wasm32",
+        feature = "wasmbind",
+        not(any(target_os = "emscripten", target_os = "wasi"))
+    ))]
     fn from_local_datetime(&self, local: &NaiveDateTime) -> LocalResult<DateTime<Local>> {
         let mut local = local.clone();
         // Get the offset from the js runtime
@@ -121,6 +134,7 @@ impl TimeZone for Local {
 
     #[cfg(not(all(
         target_arch = "wasm32",
+        feature = "wasmbind",
         not(any(target_os = "emscripten", target_os = "wasi"))
     )))]
     fn from_local_datetime(&self, local: &NaiveDateTime) -> LocalResult<DateTime<Local>> {
@@ -132,7 +146,11 @@ impl TimeZone for Local {
         Date::from_utc(*utc, *midnight.offset())
     }
 
-    #[cfg(all(target_arch = "wasm32", not(any(target_os = "emscripten", target_os = "wasi"))))]
+    #[cfg(all(
+        target_arch = "wasm32",
+        feature = "wasmbind",
+        not(any(target_os = "emscripten", target_os = "wasi"))
+    ))]
     fn from_utc_datetime(&self, utc: &NaiveDateTime) -> DateTime<Local> {
         // Get the offset from the js runtime
         let offset = FixedOffset::west((js_sys::Date::new_0().get_timezone_offset() as i32) * 60);
@@ -141,6 +159,7 @@ impl TimeZone for Local {
 
     #[cfg(not(all(
         target_arch = "wasm32",
+        feature = "wasmbind",
         not(any(target_os = "emscripten", target_os = "wasi"))
     )))]
     fn from_utc_datetime(&self, utc: &NaiveDateTime) -> DateTime<Local> {

--- a/src/offset/local/stub.rs
+++ b/src/offset/local/stub.rs
@@ -18,7 +18,11 @@ pub(super) fn now() -> DateTime<Local> {
 }
 
 /// Converts a local `NaiveDateTime` to the `time::Timespec`.
-#[cfg(not(all(target_arch = "wasm32", not(any(target_os = "emscripten", target_os = "wasi")))))]
+#[cfg(not(all(
+    target_arch = "wasm32",
+    feature = "wasmbind",
+    not(any(target_os = "emscripten", target_os = "wasi"))
+)))]
 pub(super) fn naive_to_local(d: &NaiveDateTime, local: bool) -> LocalResult<DateTime<Local>> {
     let tm = Tm {
         tm_sec: d.second() as i32,
@@ -54,7 +58,11 @@ pub(super) fn naive_to_local(d: &NaiveDateTime, local: bool) -> LocalResult<Date
 
 /// Converts a `time::Tm` struct into the timezone-aware `DateTime`.
 /// This assumes that `time` is working correctly, i.e. any error is fatal.
-#[cfg(not(all(target_arch = "wasm32", not(any(target_os = "emscripten", target_os = "wasi")))))]
+#[cfg(not(all(
+    target_arch = "wasm32",
+    feature = "wasmbind",
+    not(any(target_os = "emscripten", target_os = "wasi"))
+)))]
 fn tm_to_datetime(mut tm: Tm) -> DateTime<Local> {
     if tm.tm_sec >= 60 {
         tm.tm_nsec += (tm.tm_sec - 59) * 1_000_000_000;

--- a/src/offset/local/unix.rs
+++ b/src/offset/local/unix.rs
@@ -103,12 +103,6 @@ const TZDB_LOCATION: &str = " /system/usr/share/zoneinfo";
 #[cfg(not(target_os = "android"))]
 const TZDB_LOCATION: &str = "/usr/share/zoneinfo";
 
-#[cfg(any(target_os = "emscripten", target_os = "wasi", target_os = "solaris"))]
-fn fallback_timezone() -> Option<TimeZone> {
-    Some(TimeZone::utc())
-}
-
-#[cfg(not(any(target_os = "emscripten", target_os = "wasi", target_os = "solaris")))]
 fn fallback_timezone() -> Option<TimeZone> {
     let tz_name = iana_time_zone::get_timezone().ok()?;
     let bytes = fs::read(format!("{}/{}", TZDB_LOCATION, tz_name)).ok()?;

--- a/src/offset/utc.rs
+++ b/src/offset/utc.rs
@@ -6,7 +6,11 @@
 use core::fmt;
 #[cfg(all(
     feature = "clock",
-    not(all(target_arch = "wasm32", not(any(target_os = "emscripten", target_os = "wasi"))))
+    not(all(
+        target_arch = "wasm32",
+        feature = "wasmbind",
+        not(any(target_os = "emscripten", target_os = "wasi"))
+    ))
 ))]
 use std::time::{SystemTime, UNIX_EPOCH};
 
@@ -49,6 +53,7 @@ impl Utc {
     /// Returns a `DateTime` which corresponds to the current date and time.
     #[cfg(not(all(
         target_arch = "wasm32",
+        feature = "wasmbind",
         not(any(target_os = "emscripten", target_os = "wasi"))
     )))]
     pub fn now() -> DateTime<Utc> {
@@ -59,7 +64,11 @@ impl Utc {
     }
 
     /// Returns a `DateTime` which corresponds to the current date and time.
-    #[cfg(all(target_arch = "wasm32", not(any(target_os = "emscripten", target_os = "wasi"))))]
+    #[cfg(all(
+        target_arch = "wasm32",
+        feature = "wasmbind",
+        not(any(target_os = "emscripten", target_os = "wasi"))
+    ))]
     pub fn now() -> DateTime<Utc> {
         let now = js_sys::Date::new_0();
         DateTime::<Utc>::from(now)

--- a/tests/wasm.rs
+++ b/tests/wasm.rs
@@ -1,4 +1,8 @@
-#![cfg(all(target_arch = "wasm32", not(any(target_os = "emscripten", target_os = "wasi"))))]
+#![cfg(all(
+    target_arch = "wasm32",
+    feature = "wasmbind",
+    not(any(target_os = "emscripten", target_os = "wasi"))
+))]
 
 use self::chrono::prelude::*;
 use self::wasm_bindgen_test::*;


### PR DESCRIPTION
The circular dependency problems mentioned in <https://github.com/chronotope/chrono/issues/770#issuecomment-1211570887> where fixed in `iana-time-zone` 0.1.44. `iana-time-zone` now depends on `core-foundation-sys` instead of `core-foundation`.
